### PR TITLE
user pyserial to find serial port for battery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,3 @@ LABEL org.duckietown.label.module.type="${REPO_NAME}" \
     org.duckietown.label.maintainer="${MAINTAINER}"
 # <== Do not change the code above this line
 # <==================================================
-
-# install utility script to find devices given VID:PID pair
-COPY assets/scripts/find_device_by_vid_pid /usr/local/bin

--- a/assets/scripts/find_device_by_vid_pid
+++ b/assets/scripts/find_device_by_vid_pid
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-v=${1%:*}; p=${1#*:}  # split vid:pid into 2 vars
-v=${v#${v%%[!0]*}}; p=${p#${p%%[!0]*}}  # strip leading zeros
-grep -il "^PRODUCT=$v/$p" /sys/bus/usb/devices/*:*/uevent |
-sed s,uevent,, |
-xargs -r grep -r '^DEVNAME=' --include uevent | sed -n -e 's/^.*DEVNAME=//p'

--- a/packages/battery_drivers/battery.py
+++ b/packages/battery_drivers/battery.py
@@ -7,6 +7,7 @@ from threading import Thread
 from logging import Logger
 
 from dt_class_utils import DTReminder
+from serial.tools.list_ports import grep as serial_grep
 
 from .constants import BATTERY_VID, BATTERY_PID
 from .history import BatteryHistory
@@ -83,13 +84,8 @@ class Battery:
           }
 
     def _find_device(self):
-        cmd = ['find_device_by_vid_pid', '{}:{}'.format(BATTERY_VID, BATTERY_PID)]
-        # find USB devices
-        results = subprocess.check_output(cmd)
-        self._devices = [
-            '/dev/{}'.format(devname) for devname in results.decode('utf-8').splitlines()
-            if devname.startswith('tty')
-        ]
+        ports = serial_grep("VID:PID={}:{}".format(BATTERY_VID, BATTERY_PID))
+        self._devices = [p.device for p in ports]  # ['/dev/ttyACM0', ...]
 
     def _chew_on_data(self):
         if self._data:


### PR DESCRIPTION
Built and ran with updated source on a DB21M.

Checked by monitoring the API at: http://xx.local/health/battery
The reponses showed the battery voltage changes, so the device detection should be fine.