### PR TITLE
Shutdown support for both battery firmwares v2.0.0 and v2.0.1

### DIFF
--- a/dependencies-py3.txt
+++ b/dependencies-py3.txt
@@ -6,3 +6,6 @@ pyyaml
 
 # this is for the Nvidia Jetson boards
 jetson-stats
+
+# support for different battery firmware versions
+semver

--- a/packages/battery_drivers/battery.py
+++ b/packages/battery_drivers/battery.py
@@ -100,11 +100,11 @@ class Battery:
     def turn_off(self, timeout: int = 20, wait: bool = False, callback: Optional[Callable] = None):
         #   This is a battery shutdown, the power will be cut off after `timeout` seconds
 
-        firmware_version = self.info.get("firmware_version")
+        firmware_version = self.info.get("version")
         try:
             
             # multi-firmware support
-            if semver.compare(firmware_version[1:], "2.0.0") == 0:
+            if semver.compare(firmware_version, "2.0.0") == 0:
                 timeout_str = f'{timeout}'.zfill(2)
                 self._interaction = BatteryInteraction(
                     name="turn_off",
@@ -112,7 +112,7 @@ class Battery:
                     check=lambda d: d.get('TTL(sec)', None) == timeout,
                     callback=callback,
                 )
-            elif semver.compare(firmware_version[1:], "2.0.1") >= 0:
+            elif semver.compare(firmware_version, "2.0.1") >= 0:
                 self._interaction = BatteryInteraction(
                     name="turn_off",
                     command="QQ".encode('utf-8'),

--- a/packages/health_api/api.py
+++ b/packages/health_api/api.py
@@ -62,7 +62,8 @@ def _trigger(trigger: str):
     # special case: trigger == shutdown
     if trigger == 'shutdown':
         # shutdown the battery first, then the host
-        __battery__.turn_off(callback=lambda _: set_trigger(trigger, value))
+        timeout = request.args.get('timeout', default=10)
+        __battery__.turn_off(timeout, callback=lambda _: set_trigger(trigger, value))
     else:
         # set trigger
         try:

--- a/packages/health_api/api.py
+++ b/packages/health_api/api.py
@@ -62,8 +62,7 @@ def _trigger(trigger: str):
     # special case: trigger == shutdown
     if trigger == 'shutdown':
         # shutdown the battery first, then the host
-        timeout = request.args.get('timeout', default=10)
-        __battery__.turn_off(timeout, callback=lambda _: set_trigger(trigger, value))
+        __battery__.turn_off(callback=lambda _: set_trigger(trigger, value))
     else:
         # set trigger
         try:


### PR DESCRIPTION
Tested on a DB21M with both batteries of `v2.0.0` and `v2.0.1`. The shutdown action was triggered correctly by pressing the top button for more than 3 seconds.