### PR TITLE
DTSW-3528 Event keys minor

### DIFF
--- a/packages/robot/duckiebot/db21m.py
+++ b/packages/robot/duckiebot/db21m.py
@@ -100,7 +100,7 @@ class DB21M(Robot):
             HardwareComponent(
                 bus=self.I2C_HW_BUS_1,
                 type=ComponentType.MOTOR,
-                key="left-wheel/motor",
+                key="motor/left",
                 name="Left Motor Driver",
                 description="Motor controlling the left wheel",
                 instance=0,
@@ -116,7 +116,7 @@ class DB21M(Robot):
             HardwareComponent(
                 bus=self.I2C_HW_BUS_1,
                 type=ComponentType.MOTOR,
-                key="right-wheel/motor",
+                key="motor/right",
                 name="Right Motor Driver",
                 description="Motor controlling the right wheel",
                 instance=0,
@@ -132,7 +132,7 @@ class DB21M(Robot):
             HardwareComponent(
                 bus=self.GPIO,
                 type=ComponentType.WHEEL_ENCODER,
-                key="left-wheel/encoder",
+                key="encoder/left",
                 name="Left Wheel Encoder",
                 description="Left wheel encoder measuring how much the wheel rotates",
                 instance=0,
@@ -144,7 +144,7 @@ class DB21M(Robot):
             HardwareComponent(
                 bus=self.GPIO,
                 type=ComponentType.WHEEL_ENCODER,
-                key="right-wheel/encoder",
+                key="encoder/right",
                 name="Right Wheel Encoder",
                 description="Right wheel encoder measuring how much the wheel rotates",
                 instance=0,


### PR DESCRIPTION
make sure keys and event file uploading work for hardware tests

---

**Note** There is (at the moment) a low limit of number of characters allowed for event files "key" field. So this PR changes some keys to shorter values. In the future, either the limit should be raised, or, if this limit is kept for some reason, it should be returned in the API call as an error.