### PR TITLE
Show shutdown behaviors with dts/Dashboard shutdown

### DIFF
--- a/packages/health_api/constants.py
+++ b/packages/health_api/constants.py
@@ -1,4 +1,6 @@
 import os
+from dt_robot_utils import get_robot_name
+
 
 MHz = 10 ** 6
 GHz = 10 ** 9
@@ -11,3 +13,5 @@ HEALTH_WATCHDOG_FREQUENZY_HZ = 0.5
 DISK_IMAGE_STATS_FILE = "/data/stats/disk_image/build.json"
 
 DEBUG = os.environ.get('DEBUG', '0').lower() in ['1', 'yes', 'true']
+
+API_SHOW_SHUTDOWN_BEHAVIOR = f"http://{get_robot_name()}.local/duckiebot/shutdown_behavior"


### PR DESCRIPTION
Previously, the robot shutdown behaviors (power LEDs, LEDs, Display) are only available with the top power button.

This PR adds an API endpoint call to the `button_driver_node` in `dt-duckiebot-interface`, to make the robot show the shutdown behaviors, with health-API shutdown which is used by `dts` and Dashboard.

The tests performed are recorded in the JIRA task: DTSW-2399