### PR TITLE
Fix "Test Hardware" buttons on the Components page of the Dashboard

### DIFF
--- a/packages/robot/duckiebot/db21j.py
+++ b/packages/robot/duckiebot/db21j.py
@@ -23,19 +23,6 @@ class _DB21J_Base(DB21M):
                     [self.I2C_SW_FRONT_BUMPER_MUX_BUS_6, self.I2C_HW_BUS_1],
                     "0x29"
                 )
-        # add WiFi adapter
-        components.append(
-            HardwareComponent(
-                bus=self.USB_BUS_1,
-                type=ComponentType.USB_WIFI_DONGLE,
-                key="usb-wifi",
-                name="Wireless Adapter",
-                description="USB Wireless Adapter dongle",
-                instance=0,
-                address="0bda:c811",
-                supported=True
-            )
-        )
         # ---
         return components
 

--- a/packages/robot/duckiebot/db21m.py
+++ b/packages/robot/duckiebot/db21m.py
@@ -76,7 +76,7 @@ class DB21M(Robot):
                 # this will check for /dev/ttyACM[0]
                 address=0,
                 supported=True,
-                test_service_name="robot_http_api_node/tests/battery",
+                test_service_name="ros_http_api_node/tests/battery",
             ),
             HardwareComponent(
                 bus=self.I2C_SW_TEGRA_ADAPTER_BUS,
@@ -139,7 +139,7 @@ class DB21M(Robot):
                 address=18,
                 supported=True,
                 detectable=False,
-                test_service_name="left_wheel_encoder_node/test",
+                test_service_name="left_wheel_encoder_driver_node/test",
             ),
             HardwareComponent(
                 bus=self.GPIO,
@@ -151,7 +151,7 @@ class DB21M(Robot):
                 address=19,
                 supported=True,
                 detectable=False,
-                test_service_name="right_wheel_encoder_node/test",
+                test_service_name="right_wheel_encoder_driver_node/test",
             ),
             HardwareComponent(
                 bus=self.I2C_HW_BUS_1,
@@ -197,7 +197,7 @@ class DB21M(Robot):
                 address="0",
                 supported=True,
                 detectable=False,
-                test_service_name="robot_http_api_node/tests/wifi",
+                test_service_name="ros_http_api_node/tests/wifi",
             ),
             HardwareComponent(
                 bus=self.HAT.bus,


### PR DESCRIPTION
This pull request updates hardware component definitions for the Duckiebot models, focusing on correcting service names for testing and removing the WiFi adapter from the DB21J model. The changes improve consistency in naming and ensure the correct test services are referenced for hardware diagnostics.

**Component test service updates:**

* Changed the `test_service_name` for the battery component in `db21m.py` from `robot_http_api_node/tests/battery` to `ros_http_api_node/tests/battery` to reflect the correct service.
* Updated the left wheel encoder component's `test_service_name` from `left_wheel_encoder_node/test` to `left_wheel_encoder_driver_node/test` in `db21m.py`.
* Updated the right wheel encoder component's `test_service_name` from `right_wheel_encoder_node/test` to `right_wheel_encoder_driver_node/test` in `db21m.py`.
* Changed the WiFi component's `test_service_name` from `robot_http_api_node/tests/wifi` to `ros_http_api_node/tests/wifi` in `db21m.py`.

**Component removal:**

* Removed the WiFi adapter (`USB_WIFI_DONGLE`) definition from the DB21J model in `db21j.py`.