### PR TITLE
backport exception prevention to daffy

### DIFF
--- a/packages/health_api/tegrastats_api/utils.py
+++ b/packages/health_api/tegrastats_api/utils.py
@@ -32,10 +32,13 @@ def run_tegrastats():
 
 def _decode(output):
     gpu_temp_match = GPU_TEMP_RE.search(output)
-    KnowledgeBase.set("GPU_TEMP", float(gpu_temp_match.group(1)))
+    if gpu_temp_match:
+        KnowledgeBase.set("GPU_TEMP", float(gpu_temp_match.group(1)))
 
     gpu_usage_match = GPU_USAGE_RE.search(output)
-    KnowledgeBase.set("GPU_USAGE", float(gpu_usage_match.group(1)))
+    if gpu_usage_match:
+        KnowledgeBase.set("GPU_USAGE", float(gpu_usage_match.group(1)))
 
     gpu_power_match = GPU_POWER_RE.search(output)
-    KnowledgeBase.set("GPU_POWER", int(gpu_power_match.group(1))/1000.0)
+    if gpu_power_match:
+        KnowledgeBase.set("GPU_POWER", int(gpu_power_match.group(1))/1000.0)


### PR DESCRIPTION
We noticed spamed docker logs of 1 message per second due to an exception with the `GPU_POWER` regex not matching on any of our duckies.

I know we should migrate to `ente`, where this is fixed, but it's a matter of resources at the moment and it would be great to fix it in our current setups still. So I cherry-picked the commit from there (https://github.com/duckietown/dt-device-health/pull/24)

Pretty please? :rabbit2: 

@alex2099v1